### PR TITLE
Add CilkForRangeStmt into AST

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -2590,7 +2590,11 @@ enum CXCursorKind {
    */
   CXCursor_CilkForStmt                   = 289,
 
-  CXCursor_LastStmt = CXCursor_CilkForStmt,
+  /** A _Cilk_for range statement.
+   */
+  CXCursor_CilkForRangeStmt                   = 290,
+
+  CXCursor_LastStmt = CXCursor_CilkForRangeStmt,
 
   /**
    * Cursor that represents the translation unit itself.

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -104,10 +104,8 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
-  SourceLocation getEndLoc() const LLVM_READONLY {
-    return getCXXForRangeStmt()->getEndLoc();
-  }
+  SourceLocation getBeginLoc() const LLVM_READONLY;
+  SourceLocation getEndLoc() const LLVM_READONLY;
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -98,9 +98,7 @@ public:
     return T->getStmtClass() == CilkForRangeStmtClass;
   }
 
-  CXXForRangeStmt* getCXXForRangeStmt() const {
-    return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
-  }
+  CXXForRangeStmt* getCXXForRangeStmt() const;
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_AST_STMTCILK_H
 
 #include "clang/AST/Stmt.h"
+#include "clang/AST/StmtCXX.h"
 #include "clang/Basic/SourceLocation.h"
 
 namespace clang {
@@ -102,8 +103,13 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const LLVM_READONLY;
-  SourceLocation getEndLoc() const LLVM_READONLY;
+  SourceLocation getBeginLoc() const;
+  SourceLocation getEndLoc() const;
+
+  // Iterators
+  child_range children() {
+    return child_range(&SubExprs[0], &SubExprs[END]);
+  }
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -98,11 +98,16 @@ public:
     return T->getStmtClass() == CilkForRangeStmtClass;
   }
 
-  CXXForRangeStmt* getCXXForRangeStmt() {
+  CXXForRangeStmt* getCXXForRangeStmt() const {
     return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
   }
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
+
+  SourceLocation getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
+  SourceLocation getEndLoc() const LLVM_READONLY {
+    return getCXXForRangeStmt()->getEndLoc();
+  }
 
 };
 

--- a/clang/include/clang/AST/StmtCilk.h
+++ b/clang/include/clang/AST/StmtCilk.h
@@ -103,8 +103,8 @@ public:
 
   void setForRange(Stmt *S) { SubExprs[FORRANGE] = S; }
 
-  SourceLocation getBeginLoc() const;
-  SourceLocation getEndLoc() const;
+  SourceLocation getBeginLoc() const LLVM_READONLY;
+  SourceLocation getEndLoc() const LLVM_READONLY;
 
   // Iterators
   child_range children() {

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1221,8 +1221,6 @@ def err_cilk_for_missing_increment: Error<
   "missing loop increment expression in '_Cilk_for'">;
 def err_cilk_for_missing_semi: Error<
   "expected ';' in '_Cilk_for'">;
-def err_cilk_for_forrange_loop_not_supported: Error<
-  "'_Cilk_for' not supported on for-range loops">;
 def err_cilk_for_foreach_loop_not_supported: Error<
   "'_Cilk_for' not supported on for-each loops">;
 def err_pragma_cilk_invalid_option : Error<
@@ -1234,6 +1232,9 @@ def warn_cilk_for_following_grainsize: Warning<
   InGroup<SourceUsesCilkPlus>;
 def warn_pragma_cilk_grainsize_equals: Warning<
   "'#pragma cilk grainsize' no longer requires '='">,
+  InGroup<SourceUsesCilkPlus>;
+def warn_cilk_for_forrange_loop_experimental: Warning<
+  "'_Cilk_for' support for for-range loops is currently EXPERIMENTAL only!">,
   InGroup<SourceUsesCilkPlus>;
 
 // OpenMP support.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12098,6 +12098,7 @@ public:
                                    SourceLocation ColonLoc, Expr *Range,
                                    SourceLocation RParenLoc,
                                    BuildForRangeKind Kind);
+  StmtResult BuildCilkForRangeStmt(CXXForRangeStmt *S);
   StmtResult FinishCilkForRangeStmt(Stmt *S, Stmt *B);
 };
 

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1401,6 +1401,10 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
+
+CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
+  return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
+}
 SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
 SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
   return getCXXForRangeStmt()->getEndLoc();

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1401,3 +1401,7 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
   SubExprs[LOOPVAR] = new (C) DeclStmt(DeclGroupRef(V), VarRange.getBegin(),
                                        VarRange.getEnd());
 }
+SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
+SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
+  return getCXXForRangeStmt()->getEndLoc();
+}

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1405,7 +1405,7 @@ void CilkForStmt::setLoopVariable(const ASTContext &C, VarDecl *V) {
 CXXForRangeStmt* CilkForRangeStmt::getCXXForRangeStmt() const {
   return cast_or_null<CXXForRangeStmt>(SubExprs[FORRANGE]);
 }
-SourceLocation CilkForRangeStmt::getBeginLoc() const LLVM_READONLY { return getCXXForRangeStmt()->getBeginLoc(); }
-SourceLocation CilkForRangeStmt::getEndLoc() const LLVM_READONLY {
+SourceLocation CilkForRangeStmt::getBeginLoc() const { return getCXXForRangeStmt()->getBeginLoc(); }
+SourceLocation CilkForRangeStmt::getEndLoc() const {
   return getCXXForRangeStmt()->getEndLoc();
 }

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -167,7 +167,7 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
     break;
   case Stmt::CilkForRangeStmtClass:
     // TODO(cilkforrange): emit the right thing here!
-    EmitCXXForRangeStmt(cast<CilkForRangeStmt>(*S)->getCXXForRangeStmt(), Attrs);
+    EmitCXXForRangeStmt(*cast<CilkForRangeStmt>(*S).getCXXForRangeStmt(), Attrs);
     break;
   case Stmt::ObjCAtTryStmtClass:
     EmitObjCAtTryStmt(cast<ObjCAtTryStmt>(*S));

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -165,6 +165,10 @@ void CodeGenFunction::EmitStmt(const Stmt *S, ArrayRef<const Attr *> Attrs) {
   case Stmt::CilkForStmtClass:
     EmitCilkForStmt(cast<CilkForStmt>(*S), Attrs);
     break;
+  case Stmt::CilkForRangeStmtClass:
+    // TODO(cilkforrange): emit the right thing here!
+    EmitCXXForRangeStmt(cast<CilkForRangeStmt>(*S)->getCXXForRangeStmt(), Attrs);
+    break;
   case Stmt::ObjCAtTryStmtClass:
     EmitObjCAtTryStmt(cast<ObjCAtTryStmt>(*S));
     break;

--- a/clang/lib/Parse/ParseCilk.cpp
+++ b/clang/lib/Parse/ParseCilk.cpp
@@ -316,7 +316,7 @@ StmtResult Parser::ParseCilkForStatement(SourceLocation *TrailingElseLoc) {
 
   // TODO: Extend _Cilk_for to support these.
   if (ForRangeInfo.ParsedForRangeDecl()) {
-    Diag(ForLoc, diag::err_cilk_for_forrange_loop_not_supported);
+    Diag(ForLoc, diag::warn_cilk_for_forrange_loop_experimental);
      ExprResult CorrectedRange =
          Actions.CorrectDelayedTyposInExpr(ForRangeInfo.RangeExpr.get());
     // TODO(arvid): uncomment this

--- a/clang/lib/Sema/SemaExceptionSpec.cpp
+++ b/clang/lib/Sema/SemaExceptionSpec.cpp
@@ -1483,6 +1483,7 @@ CanThrowResult Sema::canThrow(const Stmt *S) {
   case Stmt::CilkSpawnStmtClass:
   case Stmt::CilkSyncStmtClass:
   case Stmt::CilkForStmtClass:
+  case Stmt::CilkForRangeStmtClass:
     return canSubStmtsThrow(*this, S);
 
   case Stmt::DeclStmtClass: {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3507,12 +3507,16 @@ StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *In
                                       BuildForRangeKind Kind) {
   // we wrap the for range!
   SourceLocation EmptyCoawaitLoc;
-  StmtResult ForRangeStmt = this->ActOnCXXForRangeStmt(
+  StmtResult ForRangeStmt = ActOnCXXForRangeStmt(
       S, ForLoc, EmptyCoawaitLoc, InitStmt,
       First, ColonLoc, Range,
       RParenLoc, Kind);
 
-  return ForRangeStmt;
+  return BuildCilkForRangeStmt(ForRangeStmt);
+}
+
+StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+  return new (Context) CilkForRangeStmt(Context, ForRange);
 }
 
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3498,7 +3498,12 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
 
 // TODO: add comment
 StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
-  return FinishCXXForRangeStmt(cast<CilkForRangeStmt>(S)->getCXXForRangeStmt(), B);
+  CilkForRangeStmt *CilkForRange = cast<CilkForRangeStmt>(S);
+  StmtResult ForRange = FinishCXXForRangeStmt(CilkForRange->getCXXForRangeStmt(), B);
+  if (ForRange.isInvalid())
+    return StmtError();
+  CilkForRange->setForRange(ForRange.get());
+  return CilkForRange;
 }
 
 StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *InitStmt,

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3498,7 +3498,7 @@ static void SearchForReturnInStmt(Sema &Self, Stmt *S) {
 
 // TODO: add comment
 StmtResult Sema::FinishCilkForRangeStmt(Stmt *S, Stmt *B) {
-  return this->FinishCXXForRangeStmt(S, B);
+  return FinishCXXForRangeStmt(cast<CilkForRangeStmt>(S)->getCXXForRangeStmt(), B);
 }
 
 StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *InitStmt,

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -3512,7 +3512,10 @@ StmtResult Sema::ActOnCilkForRangeStmt(Scope *S, SourceLocation ForLoc, Stmt *In
       First, ColonLoc, Range,
       RParenLoc, Kind);
 
-  return BuildCilkForRangeStmt(ForRangeStmt);
+  if (ForRangeStmt.isInvalid())
+    return ForRangeStmt;
+
+  return BuildCilkForRangeStmt(cast_or_null<CXXForRangeStmt>(ForRangeStmt.get()));
 }
 
 StmtResult Sema::BuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1368,6 +1368,14 @@ public:
                                       RParenLoc, Body, LoopVar);
   }
 
+  // Builds a new Cilk for range statement.
+  // TODO: this feels very hacky
+  StmtResult RebuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+    // we don't reconstruct the for range into its constituent parts,
+    // but rather let the ForRange handle it for us
+    return getSema().BuildCilkForRangeStmt(ForRange);
+  }
+
   /// Build a new goto statement.
   ///
   /// By default, performs semantic analysis to build the new statement.
@@ -13859,6 +13867,16 @@ TreeTransform<Derived>::TransformCilkForStmt(CilkForStmt *S) {
       S->getCilkForLoc(), S->getLParenLoc(), Init.get(), Limit.get(),
       InitCond, Begin.get(), End.get(), Cond, FullInc, S->getRParenLoc(),
       LoopVar, Body.get());
+}
+
+template<typename Derived>
+StmtResult
+TreeTransform<Derived>::TransformCilkForRangeStmt(CilkForRangeStmt *S) {
+  CXXForRangeStmt ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
+  if (ForRange.isInvalid())
+    return StmtError();
+
+  return getDerived().RebuildCilkForRangeStmt(ForRange.get());
 }
 
 } // end namespace clang

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -1370,10 +1370,10 @@ public:
 
   // Builds a new Cilk for range statement.
   // TODO: this feels very hacky
-  StmtResult RebuildCilkForRangeStmt(CXXForRangeStmt *ForRange) {
+  StmtResult RebuildCilkForRangeStmt(Stmt *ForRange) {
     // we don't reconstruct the for range into its constituent parts,
     // but rather let the ForRange handle it for us
-    return getSema().BuildCilkForRangeStmt(ForRange);
+    return getSema().BuildCilkForRangeStmt(cast_or_null<CXXForRangeStmt>(ForRange));
   }
 
   /// Build a new goto statement.
@@ -13872,7 +13872,7 @@ TreeTransform<Derived>::TransformCilkForStmt(CilkForStmt *S) {
 template<typename Derived>
 StmtResult
 TreeTransform<Derived>::TransformCilkForRangeStmt(CilkForRangeStmt *S) {
-  CXXForRangeStmt ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
+  StmtResult ForRange = getDerived().TransformStmt(S->getCXXForRangeStmt());
   if (ForRange.isInvalid())
     return StmtError();
 

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -2793,6 +2793,10 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       S = new (Context) CilkForStmt(Empty);
       break;
 
+    case STMT_CILKFORRANGE:
+      S = new (Context) CilkForRangeStmt(Empty);
+      break;
+
     case EXPR_PREDEFINED:
       S = PredefinedExpr::CreateEmpty(
           Context,

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5584,6 +5584,8 @@ CXString clang_getCursorKindSpelling(enum CXCursorKind Kind) {
     return cxstring::createRef("CilkSyncStmt");
   case CXCursor_CilkForStmt:
     return cxstring::createRef("CilkForStmt");
+  case CXCursor_CilkForRangeStmt:
+    return cxstring::createRef("CilkForRangeStmt");
   }
 
   llvm_unreachable("Unhandled CXCursorKind");

--- a/clang/tools/libclang/CXCursor.cpp
+++ b/clang/tools/libclang/CXCursor.cpp
@@ -266,6 +266,10 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
     K = CXCursor_CilkForStmt;
     break;
 
+  case Stmt::CilkForRangeStmtClass:
+    K = CXCursor_CilkForRangeStmt;
+    break;
+
   case Stmt::ArrayTypeTraitExprClass:
   case Stmt::AsTypeExprClass:
   case Stmt::AtomicExprClass:


### PR DESCRIPTION
This PR adds support for the range-based for syntax with the `cilk_for` keyword. A new AST node `CilkForRangeStmt` is created to correspond to this new syntax. At the moment, the `CilkForRangeStmt` simply wraps a normal `CXXForRangeStmt`, and in codegen, it simply emits the normal, serial for-range code.

There are some sketchy things going on in many places here... We probably want to fix those sketchy things at some point